### PR TITLE
Add Internal link choice and a Copy button

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
 		'jsdoc/require-jsdoc': 'off',
 		'jsdoc/tag-lines': 'off',
 		'vue/first-attribute-linebreak': 'off',
+		'no-console': 'off',
 		'import/extensions': 'off'
 	}
 }

--- a/README.md
+++ b/README.md
@@ -60,9 +60,36 @@ You can then press "Close for all" if you want to hide the app for all participa
 
 ## Copy link and close window
 
-This button will copy the desired link and might close the window if the window has been open with a js pickerWindow button like this 
+This button will copy the desired link and can close the picker app window if it has been opened with a js `pickerWindow` button like 
 ```
-      newButton.onclick = () => {
-        pickerWindow = window.open('/nextcloud/apps/picker/single-link', 'pickerWindow', 'popup');
-      };
+newButton.onclick = () => {
+  pickerWindow = window.open('/nextcloud/apps/picker/single-link', 'pickerWindow', 'popup');
+};
+```
+or can close the iframe if it has been opened with a js button similar to
+```
+newButton.onclick = () => {
+  // Create the iframe element
+  var pickerFrame = document.createElement('iframe';
+  pickerFrame.id = 'pickerFrame';
+  pickerFrame.height = '800'; // set the height
+  pickerFrame.width = 600'; // set the width
+  pickerFrame.src = '/nextcloud/apps/picker/single-link'; // Set the source URL
+  pickerFrame.style.border = 'none'; // Remove the default border
+  // Set the iframe styles to position it in the middle and on top
+  pickerFrame.style.position = 'fixed';
+  pickerFrame.style.top = '50%';
+  pickerFrame.style.left = '50%';
+  pickerFrame.style.transform = 'translate(-50%, -50%)';
+  pickerFrame.style.zIndex = '9999'; // Adjust this value as needed
+  // Append the iframe to the document body
+  document.body.appendChild(pickerFrame);
+};
+```
+and the opener has also the following `closePickerIframe` function (called by the iframe) :
+```
+function closePickerIframe() {
+  const pickerFrame = document.getElementById('pickerFrame');
+  document.body.removeChild(pickerFrame); // Remove the iframe
+}
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can then press "Close for all" if you want to hide the app for all participa
 This button will copy the desired link and can close the picker app window if it has been opened with a js `pickerWindow` button like 
 ```
 newButton.onclick = () => {
-  pickerWindow = window.open('/nextcloud/apps/picker/single-link', 'pickerWindow', 'popup');
+  pickerWindow = window.open('https://your.nextcloud.org/index.php/apps/picker/single-link', 'pickerWindow', 'popup');
 };
 ```
 or can close the iframe if it has been opened with a js button similar to
@@ -74,7 +74,7 @@ newButton.onclick = () => {
   pickerFrame.id = 'pickerFrame';
   pickerFrame.height = '800'; // set the height
   pickerFrame.width = 600'; // set the width
-  pickerFrame.src = '/nextcloud/apps/picker/single-link'; // Set the source URL
+  pickerFrame.src = 'https://your.nextcloud.org/index.php/apps/picker/single-link'; // Set the source URL
   pickerFrame.style.border = 'none'; // Remove the default border
   // Set the iframe styles to position it in the middle and on top
   pickerFrame.style.position = 'fixed';

--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ If the file file you selected is supported by Nextcloud Text, Nextcloud Office o
 you will be able to collaborate on this file with all the call participants.
 
 You can then press "Close for all" if you want to hide the app for all participants.
+
+## Copy link and close window
+
+This button will copy the desired link and might close the window if the window has been open with a js pickerWindow button like this 
+```
+      newButton.onclick = () => {
+        pickerWindow = window.open('/nextcloud/apps/picker/single-link', 'pickerWindow', 'popup');
+      };
+```

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "@nextcloud/router": "^2.0.0",
     "@nextcloud/vue": "^7.0.0",
     "vue": "^2.6.14",
-    "vue-material-design-icons": "^5.0.0"
+    "vue-material-design-icons": "^5.0.0",
+    "lodash": "^4.17.21",
+    "webdav": "4.11.3"
   },
   "engines": {
     "node": "^20.0.0",

--- a/src/PermissionsModal.vue
+++ b/src/PermissionsModal.vue
@@ -34,6 +34,9 @@
 						<PencilIcon v-else-if="p.id === 'write'"
 							class="perm-icon"
 							:size="20" />
+						<InternalIcon v-else-if="p.id === 'internal'"
+							class="perm-icon"
+							:size="20" />
 						<span class="perm-title">
 							{{ p.label }}
 						</span>
@@ -44,12 +47,20 @@
 						{{ t('picker', 'Cancel') }}
 					</NcButton>
 					<NcButton type="primary"
-						@click="onValidate">
+						@click="onOpen">
 						<template #icon>
 							<CheckIcon
 								:size="20" />
 						</template>
-						{{ t('picker', 'Start collaborating') }}
+						{{ t('picker', 'Open file') }}
+					</NcButton>
+					<NcButton type="primary"
+						@click="onCopy">
+						<template #icon>
+							<CheckIcon
+								:size="20" />
+						</template>
+						{{ t('picker', 'Copy link and close window') }}
 					</NcButton>
 				</div>
 			</div>
@@ -61,6 +72,7 @@
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import EyeIcon from 'vue-material-design-icons/Eye.vue'
+import InternalIcon from 'vue-material-design-icons/OpenInNew.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import { generateUrl } from '@nextcloud/router'
@@ -74,6 +86,10 @@ const permissions = [
 	{
 		id: 'write',
 		label: t('picker', 'Edit'),
+	},
+	{
+		id: 'internal',
+		label: t('picker', 'Internal link'),
 	},
 	/*
 	{
@@ -92,6 +108,7 @@ export default {
 		CheckIcon,
 		PencilIcon,
 		EyeIcon,
+		InternalIcon,
 	},
 
 	props: {
@@ -139,9 +156,13 @@ export default {
 			this.open = false
 			this.$emit('closed')
 		},
-		onValidate() {
+		onOpen() {
 			this.open = false
-			this.$emit('validate', this.filePath, this.selectedPermission)
+			this.$emit('open', this.filePath, this.selectedPermission)
+		},
+		onCopy() {
+			this.open = false
+			this.$emit('copy', this.filePath, this.selectedPermission)
 		},
 	},
 }

--- a/src/main.js
+++ b/src/main.js
@@ -98,7 +98,11 @@ function editShare(shareId, permission, action) {
 			console.debug('[picker main] after edit, there is NO webex app => copyShareLink')
 			navigator.clipboard.writeText(publicLinkUrl).then(() => {
 				console.debug('Link copied to clipboard successfully')
-				window.opener.window.pickerWindow.close()
+				if (window.opener) {
+					window.opener.window.pickerWindow.close()
+				} else {
+					window.parent.closePickerIframe()
+				}
 			})
 		}
 	}).catch((error) => {
@@ -147,7 +151,11 @@ function getInternalLink(filePath, action) {
 			console.debug('[picker main] after getting Internal Link, there is NO webex app => copyInternalLinkURL')
 			navigator.clipboard.writeText(internalLinkURL).then(() => {
 				console.debug('Internal Link copied to clipboard successfully')
-				window.opener.window.pickerWindow.close()
+				if (window.opener) {
+					window.opener.window.pickerWindow.close()
+				} else {
+					window.parent.closePickerIframe()
+				}
 			})
 		}
 	}).catch(error => {

--- a/src/main.js
+++ b/src/main.js
@@ -154,6 +154,7 @@ function getInternalLink(filePath, action) {
 				if (window.opener) {
 					window.opener.window.pickerWindow.close()
 				} else {
+					openFilePicker()
 					window.parent.closePickerIframe()
 				}
 			})

--- a/src/main.js
+++ b/src/main.js
@@ -2,12 +2,49 @@ import Vue from 'vue'
 import './bootstrap.js'
 import PermissionsModal from './PermissionsModal.vue'
 
-import { generateOcsUrl, generateUrl } from '@nextcloud/router'
+import { generateOcsUrl, generateUrl, generateRemoteUrl } from '@nextcloud/router'
 import { dirname } from '@nextcloud/paths'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import moment from '@nextcloud/moment'
+import * as webdav from 'webdav'
+import memoize from 'lodash/fp/memoize.js'
+import { getCurrentUser } from '@nextcloud/auth'
 import '../css/main.scss'
+export const getClient = memoize((service) => {
+	// Add this so the server knows it is a request from the browser
+	axios.defaults.headers['X-Requested-With'] = 'XMLHttpRequest'
+
+	// force our axios
+	const patcher = webdav.getPatcher()
+	patcher.patch('request', axios)
+
+	return webdav.createClient(
+		generateRemoteUrl(`dav/${service}/${getCurrentUser().uid}`),
+	)
+})
+export function getFileId(filePath) {
+	return getClient('files').stat(filePath, {
+		details: true,
+		data: `<?xml version="1.0"?>
+			<d:propfind
+			xmlns:d="DAV:"
+			xmlns:oc="http://owncloud.org/ns"
+			xmlns:nc="http://nextcloud.org/ns">
+				<d:prop>
+					<oc:fileid />
+				</d:prop>
+			</d:propfind>`,
+	}).then((fileId) => {
+		return fileId?.data?.props?.fileid
+	}).catch((error) => {
+		console.error(error)
+	})
+}
+export function generateAbsoluteUrl(url, params, options) {
+	const fullPath = generateUrl(url, params, options)
+	return `${window.location.origin}${fullPath}`
+}
 
 let permVue
 let lastPath = null
@@ -33,7 +70,7 @@ if (window.Webex?.Application) {
 	console.debug('[picker main] No webex app')
 }
 
-function editShare(shareId, permission) {
+function editShare(shareId, permission, action) {
 	const url = generateOcsUrl('/apps/files_sharing/api/v1/shares/{shareId}', { shareId })
 	const req = {
 		permissions: permission === 'write' ? 3 : undefined,
@@ -54,9 +91,15 @@ function editShare(shareId, permission) {
 			}).catch((error) => {
 				console.error(error)
 			})
-		} else {
+		} else if (action === 'open') {
 			console.debug('[picker main] after edit, there is NO webex app => setShareUrl')
 			window.location = publicLinkUrl
+		} else if (action === 'copy') {
+			console.debug('[picker main] after edit, there is NO webex app => copyShareLink')
+			navigator.clipboard.writeText(publicLinkUrl).then(() => {
+				console.debug('Link copied to clipboard successfully')
+				window.opener.window.pickerWindow.close()
+			})
 		}
 	}).catch((error) => {
 		console.debug(error)
@@ -64,7 +107,7 @@ function editShare(shareId, permission) {
 	})
 }
 
-function createPublicLink(path, permission) {
+function createPublicLink(path, permission, action) {
 	const url = generateOcsUrl('/apps/files_sharing/api/v1/shares')
 	const req = {
 		path,
@@ -74,10 +117,42 @@ function createPublicLink(path, permission) {
 	axios.post(url, req).then((response) => {
 		console.debug('ADD SUCCESS', response.data?.ocs?.data)
 		const shareId = response.data?.ocs?.data?.id
-		editShare(shareId, permission)
+		editShare(shareId, permission, action)
 	}).catch((error) => {
 		console.error(error)
 		showError(t('picker', 'Error while creating the shared access'))
+	})
+}
+
+function getInternalLink(filePath, action) {
+	getFileId(filePath).then(fileId => {
+		const internalLinkURL = generateAbsoluteUrl('/f/') + fileId
+		console.debug('internalLinkURL is', internalLinkURL)
+		if (webexApp) {
+			console.debug('[picker main] after getting Internal Link, there is a webex app => setInternalLinkURL')
+			// const token = response.data?.ocs?.data?.token
+			// const fileId = response.data?.ocs?.data?.file_source
+			// const urlForWebex = generateUrl('/apps/picker/webex-share/{token}?fileId={fileId}', { token, fileId })
+			// webexApp.setShareUrl(urlForWebex, urlForWebex, t('picker', 'Nextcloud picker')).then(() => {
+			webexApp.setInternalLinkURL(internalLinkURL, internalLinkURL, t('picker', 'Nextcloud picker')).then(() => {
+				console.debug('[picker main] setinternalLinkURL.then => change location to', internalLinkURL)
+				window.location = internalLinkURL
+			}).catch((error) => {
+				console.error(error)
+			})
+		} else if (action === 'open') {
+			console.debug('[picker main] after getting Internal Link, there is NO webex app => setInternalLinkURL')
+			window.location = internalLinkURL
+		} else if (action === 'copy') {
+			console.debug('[picker main] after getting Internal Link, there is NO webex app => copyInternalLinkURL')
+			navigator.clipboard.writeText(internalLinkURL).then(() => {
+				console.debug('Internal Link copied to clipboard successfully')
+				window.opener.window.pickerWindow.close()
+			})
+		}
+	}).catch(error => {
+		console.error(error)
+		showError(t('picker', 'Error getting fileId'))
 	})
 }
 
@@ -116,8 +191,20 @@ document.addEventListener('DOMContentLoaded', (event) => {
 		openFilePicker()
 	})
 
-	permVue.$on('validate', (filePath, permission) => {
-		createPublicLink(filePath, permission)
+	permVue.$on('open', (filePath, permission) => {
+		if (permission === 'internal') {
+			getInternalLink(filePath, 'open')
+		} else {
+			createPublicLink(filePath, permission, 'open')
+		}
+	})
+
+	permVue.$on('copy', (filePath, permission) => {
+		if (permission === 'internal') {
+			getInternalLink(filePath, 'copy')
+		} else {
+			createPublicLink(filePath, permission, 'copy')
+		}
 	})
 
 	openFilePicker()


### PR DESCRIPTION
It is a proposal, a proof of concept. 
Don't hesitate to tell me what should be change. 
package-lock.json file isn't updated so an "npm update" is necessary.

An idea I had to move toward a more efficient tool would be to remove all three button
"Cancel"
"Open file"
"Copy link and close window"

and to make the three options "Read", "Write" and "Internal link" becoming button that directly copy the link and close the window, and even ideally move these three buttons to the first page.
However, I didn't want to be that radical in my proposal so I keep it the way oit is working now and just added a new option to get the Internal link and a button to copy link and close window keeping the original button that open the file (I just renamed it to be more comprehensible).